### PR TITLE
YoonYn9915 / 7월 1주차 / 3문제

### DIFF
--- a/YoonYn9915/Graph/2024-07-05-[백준]-#11725-트리의 부모 찾기.py
+++ b/YoonYn9915/Graph/2024-07-05-[백준]-#11725-트리의 부모 찾기.py
@@ -1,0 +1,39 @@
+from collections import deque, defaultdict
+
+def bfs(graph, start_node, n, answer):
+    queue = deque([start_node])
+    visited = [False] * n
+    visited[start_node] = True
+
+    while queue:
+        current_node = queue.popleft()
+
+        for next_node in graph[current_node]:
+            if not visited[next_node]:
+                queue.append(next_node)
+                visited[next_node] = True
+                answer[next_node] = current_node
+
+    return answer
+
+# 입력값 받기
+n = int(input())
+edges = [list(map(int, input().split())) for _ in range(n - 1)]
+
+# 그래프 초기화 (인접 리스트 사용)
+graph = defaultdict(list)
+
+for edge in edges:
+    node1, node2 = edge
+    graph[node1 - 1].append(node2 - 1)
+    graph[node2 - 1].append(node1 - 1)
+
+# 정답 배열 초기화
+answer = [0] * n
+
+# BFS 실행 (0번 노드를 루트로 설정)
+answer = bfs(graph, 0, n, answer)
+
+# 결과 출력 (루트 노드를 제외한 노드들의 부모 노드를 출력)
+for parent in answer[1:]:
+    print(parent + 1)

--- a/YoonYn9915/Graph/2024-07-08-[백준]-#2178-미로찾기.py
+++ b/YoonYn9915/Graph/2024-07-08-[백준]-#2178-미로찾기.py
@@ -1,0 +1,38 @@
+from collections import deque
+
+
+def bfs(graph, visited):
+    dx = [-1, 1, 0, 0]
+    dy = [0, 0, -1, 1]
+
+    queue = deque([(0, 0, 1)])  # (x, y, distance)
+    visited[0][0] = 1
+
+    while queue:
+        x, y, dist = queue.popleft()
+
+        if x == n - 1 and y == m - 1:
+            return dist
+
+        for i in range(4):
+            row = x + dx[i]
+            col = y + dy[i]
+
+            if 0 <= row < n and 0 <= col < m and visited[row][col] == 0 and graph[row][col] == 1:
+                visited[row][col] = 1
+                queue.append((row, col, dist + 1))
+
+    return -1  # 목적지에 도달할 수 없는 경우
+
+
+n, m = map(int, input().split())
+graph = []
+visited = [[0] * m for _ in range(n)]
+
+for _ in range(n):
+    line = input()
+    graph.append([int(char) for char in line])
+
+min_answer = bfs(graph, visited)
+
+print(min_answer)

--- a/YoonYn9915/dp/2024-07-08-[백준]-#2839-설탕배달.py
+++ b/YoonYn9915/dp/2024-07-08-[백준]-#2839-설탕배달.py
@@ -1,0 +1,27 @@
+n = int(input())
+
+dp = [-1 for _ in range(5001)]
+dp[3] = 1
+dp[5] = 1
+
+if n <= 5:
+    print(dp[n])
+else:
+    for i in range(6, n + 1):
+        a, b = dp[i], dp[i]
+
+        if dp[i - 5] != -1:
+            a = dp[i - 5]
+        if dp[i - 3] != -1:
+            b = dp[i - 3]
+
+        if a > 0 and b > 0:
+            dp[i] = min(a + 1, b + 1)
+        elif a > 0 and b < 0:
+            dp[i] = a + 1
+        elif a < 0 and b > 0:
+            dp[i] = b + 1
+        else:
+            dp[i] = -1
+
+    print(dp[n])


### PR DESCRIPTION

## 주 목표 문제 수: 3개
> 푼 문제
- [백준 #11725. 트리의 부모 찾기](https://www.acmicpc.net/problem/11725): 그래프/ 실버2
- [백준 #2178. 미로 찾기](https://www.acmicpc.net/problem/2178): 그래프/ 실버1
- [백준 #2839. 설탕 배달](https://www.acmicpc.net/problem/2839): dp/ 실버4

---
## [백준 #11725. 트리의 부모 찾기](https://www.acmicpc.net/problem/11725): 그래프 / 실버2
정리한 링크: https://www.notion.so/5fffcfea12544c2cacf03b2b5bfada5a

### 🚩플로우 (선택)
이 문제는 노드의 개수 n과 n-1개의 간선정보를 받아서 그래프를 만든 후 그 그래프를 bfs 혹은 dfs로 탐색하며 탐색하는 노드마다 부모 노드의 정보를 저장한 후 출력하는 문제이다.

위 문제를 풀기 위해서는 그래프의 모든 노드를 탐색해야 한다고 판단했고 부모의 정보를 저장해야 하기 때문에 너비 우선의(부모와 자식은 너비를 기준으로 row로 나뉘니까) bfs가 더 편하다고 생각했다.

나는 다음과 같은 순서를 정했다.

1. 노드의 개수 n, 간선 n-1개(연결된 노드 두 개) 입력 받기
2. 2차원 graph 배열만들고 0으로 초기화. row를 기준으로 연결되어있는 col번째에 1 저장.
3. visited 배열 생성, answer배열 생성. bfs 돌림.(너비 별로 부모 자식이 나뉘기 때문에 bfs로 결정. dfs로 해도 될거 같긴 하다)
4.  bfs 함수 안에선 먼저, 현재 노드를 queue에 넣고 방문처리한다. queue가 비어있는지 확인한 후, queue에서 popleft해서 현재노드를 설정한 후 그 노드에 대해 n만큼 반복문을 돌린다.
5.  조건문에서 부모노드가 아니면서 graph 값이 1이면 queue에 넣고 answer배열에 부모노드를 저장한다.

### 🚩제출한 코드
```
from collections import deque, defaultdict

def bfs(graph, start_node, n, answer):
    queue = deque([start_node])
    visited = [False] * n
    visited[start_node] = True

    while queue:
        current_node = queue.popleft()

        for next_node in graph[current_node]:
            if not visited[next_node]:
                queue.append(next_node)
                visited[next_node] = True
                answer[next_node] = current_node

    return answer

# 입력값 받기
n = int(input())
edges = [list(map(int, input().split())) for _ in range(n - 1)]

# 그래프 초기화 (인접 리스트 사용)
graph = defaultdict(list)

for edge in edges:
    node1, node2 = edge
    graph[node1 - 1].append(node2 - 1)
    graph[node2 - 1].append(node1 - 1)

# 정답 배열 초기화
answer = [0] * n

# BFS 실행 (0번 노드를 루트로 설정)
answer = bfs(graph, 0, n, answer)

# 결과 출력 (루트 노드를 제외한 노드들의 부모 노드를 출력)
for parent in answer[1:]:
    print(parent + 1)

```

### 💡TIL
-  N이 100,000개 정도면 2차원 배열로 해도 되겠지 했는데 메모리 용량 초과되더라. 결국 2차원 배열을 defalultdict(list)를 이용해서 딕셔너리로 수정했다.

---
## [백준 #11725. 미로 찾기](https://www.acmicpc.net/problem/2178): 그래프 / 실버1
정리한 링크: https://www.notion.so/21bbb4cf1bd6478b9715d6a67a145805

### 🚩플로우 (선택)
이 문제는 최소 비용 미로 찾기 문제이다.  모든 간선의 비용이 같기 때문에 kruskal 같은 최소 비용 전용 알고리즘 대신 dfs나 bfs를 써도 문제 없다고 판단. 

미로 찾기 문제는 dfs가 많이 쓰일 것 같아서 dfs로 구현하고자 했다. 지금까지 풀어온 그래프 문제와 비슷해서 풀기 어렵지 않았다.

나는 다음과 같은 순서를 정했다.

1. 그래프의 행 n, 열 m을 입력받는다.
2. 2차원 graph 배열 만들고 값 입력받는다.
3. visited 배열 생성, 최소 비용을 저장할 min_answer 생성
4.  dfs 함수 안에선 현재 노드의 위치가 도착점인지 확인한다. 도착점이면 지금까지의 비용과 min_answer를 비교한후 min_answer를 업데이트한다.
5. 현재 노드의 위치가 도착점이 아니라면 상하좌우 4번씩 방문해서 조건을 판단하고 만족하면 재귀적으로 다음 노드로 이동한다.

### 🚩제출한 코드
```
from collections import deque


def bfs(graph, visited):
    dx = [-1, 1, 0, 0]
    dy = [0, 0, -1, 1]

    queue = deque([(0, 0, 1)])  # (x, y, distance)
    visited[0][0] = 1

    while queue:
        x, y, dist = queue.popleft()

        if x == n - 1 and y == m - 1:
            return dist

        for i in range(4):
            row = x + dx[i]
            col = y + dy[i]

            if 0 <= row < n and 0 <= col < m and visited[row][col] == 0 and graph[row][col] == 1:
                visited[row][col] = 1
                queue.append((row, col, dist + 1))

    return -1  # 목적지에 도달할 수 없는 경우


n, m = map(int, input().split())
graph = []
visited = [[0] * m for _ in range(n)]

for _ in range(n):
    line = input()
    graph.append([int(char) for char in line])

min_answer = bfs(graph, visited)

print(min_answer)

```

### 💡TIL
-  첫 제출코드에서는 dfs로 구현했는데 시간초과가 떳다. 검색해보니 최소 비용(optimal한 값)을 구할때는 bfs가 더 빠르다고 하고 중간 값(꼭 최소나 최대가 아닌 값)을 구할떄는 dfs로 해도 괜찮다고 한다.  bfs로 다시 구현했다. 대부분의 그래프 탐색 문제에서는 bfs와 dfs 둘 다 사용할 수 있는데, 어떤 상황에서 어떤 방법을 사용할 지 더 많이 고민해봐야겠다.


---
## [백준 #2839. 설탕 배달](https://www.acmicpc.net/problem/2839): dp / 실버4
정리한 링크: https://www.notion.so/21bbb4cf1bd6478b9715d6a67a145805

### 🚩플로우 (선택)
dp테이블에는 각 무게 별 사용하는 봉투의 최솟값을 저장한다.  

점화식: dp[n] = (dp[n-3] or dp[n-5]) +1

봉투의 종류는 3kg, 5kg이므로 사용자 입력값 n을 기준으로 dp[n-3], dp[n-5]를 보고 +1해야 함.

case 1. dp[n-3], dp[n-5]가 둘다 존재하는 경우

dp[n-3], dp[n-5]의 값을 min으로 비교하여 작은 값에 +1한다.

case 2. dp[n-3], dp[n-5] 둘 중 하나만 존재하는 경우

존재하는 값이 최소 봉투의 값이므로 +1한다.

case 3. dp[n-3], dp[n-5] 둘 다 존재하지 않는 경우

3kg, 5kg 봉투로 딱 나누어 떨어지지 않으므로 -1한다.

나는 다음과 같은 순서를 정했다.

1. 사용자 입력으로 n을 받는다
2. dp배열을 -1로 초기화
3. dp[1], dp[2], dp[3], dp[4], dp[5]를 각각 -1, -1, 1, -1, 1로 초기화
4. 6부터 n+1까지 dp[i-3], dp[i-5]를 확인 후 
    1. 위의 case 1, case 2, case 3에 따라 처리

### 🚩제출한 코드
```
n = int(input())

dp = [-1 for _ in range(5001)]
dp[3] = 1
dp[5] = 1

if n <= 5:
    print(dp[n])
else:
    for i in range(6, n + 1):
        a, b = dp[i], dp[i]

        if dp[i - 5] != -1:
            a = dp[i - 5]
        if dp[i - 3] != -1:
            b = dp[i - 3]

        if a > 0 and b > 0:
            dp[i] = min(a + 1, b + 1)
        elif a > 0 and b < 0:
            dp[i] = a + 1
        elif a < 0 and b > 0:
            dp[i] = b + 1
        else:
            dp[i] = -1

    print(dp[n])

```

