### PR TITLE
YoonYn9915 / 9월 4주차 / 2문제

### DIFF
--- a/YoonYn9915/Graph/2024-09-30-[백준]-#2644-촌수계산.py
+++ b/YoonYn9915/Graph/2024-09-30-[백준]-#2644-촌수계산.py
@@ -1,0 +1,30 @@
+
+N = int(input())
+A, B = map(int, input().split())
+M = int(input())
+graph = [[] for _ in range(N+1)]
+visited = [False] * (N+1)
+result = []
+
+for _ in range(M):
+  x, y = map(int, input().split())
+  graph[x].append(y)
+  graph[y].append(x)
+
+# dfs
+def dfs(v, num):
+  num += 1
+  visited[v] = True
+
+  if v == B:
+    result.append(num)
+
+  for i in graph[v]:
+    if not visited[i]:
+      dfs(i, num)
+
+dfs(A, 0)
+if len(result) == 0:
+  print(-1)
+else:
+  print(result[0]-1)

--- a/YoonYn9915/Graph/2024-09-30[백준]-#14888-연산자 끼워넣기.py
+++ b/YoonYn9915/Graph/2024-09-30[백준]-#14888-연산자 끼워넣기.py
@@ -1,0 +1,31 @@
+
+def dfs(level, total, plus, minus, mul, div):
+    global max_result
+    global min_result
+    global n
+
+    #종료 조건
+    if level == n:
+        max_result = max(total, max_result)
+        min_result = min(total, min_result)
+
+    if plus != 0:
+        dfs(level + 1, total + nums[level], plus - 1, minus, mul, div)
+    if minus != 0:
+        dfs(level + 1, total - nums[level], plus, minus - 1, mul, div)
+    if mul != 0:
+        dfs(level + 1, total * nums[level], plus, minus, mul - 1, div)
+    if div != 0:
+        dfs(level + 1, int(total / nums[level]), plus, minus, mul, div - 1)
+
+
+n = int(input())
+nums = list(map(int, input().split()))
+op = list(map(int, input().split()))
+
+max_result = -int(1e9)
+min_result = int(1e9)
+dfs(1, nums[0], op[0], op[1], op[2], op[3])
+
+print(max_result)
+print(min_result)


### PR DESCRIPTION
## 주 목표 문제 수: 2개
> 푼 문제
- [백준 #14888. 연산자 끼워넣기](https://www.acmicpc.net/problem/14888): 그래프, 브루트포스 / 실버1
- [백준 #2644. 촌수 계산](https://www.acmicpc.net/problem/2644): 그래프 / 실버2

---
## [백준 #14888. 연산자 끼워넣기](https://www.acmicpc.net/problem/14888): 그래프, 브루트포스 / 실버1

정리한 링크: https://purple-jury-c2d.notion.site/1111eff69e9e80339e66e2a1e83ed6a4?pvs=4

### 🚩플로우 (선택)
> - **입력받기**:
    
    먼저 사용자로부터 숫자 개수 `n`, 숫자 리스트 `nums`, 그리고 연산자 리스트 `op` (덧셈, 뺄셈, 곱셈, 나눗셈 각각의 개수)를 입력받는다. 이때 `op`는 각 연산자가 몇 번 사용될 수 있는지를 나타낸다.
    
- **DFS 재귀 호출**:
    
    `dfs()` 함수는 깊이 우선 탐색(DFS)을 이용하여 가능한 모든 경우의 수를 탐색하는 방식으로 구현되어 있다. 각 연산자를 남은 개수에 따라 사용하며, 재귀적으로 호출된다.
    
- **재귀 종료 조건**:
    
    `level` 값이 `n`에 도달하면, 즉 모든 숫자를 사용한 경우, 현재까지의 계산 결과 `total`을 전역 변수 `max_result`와 `min_result`와 비교하여 갱신한다. 이는 가장 큰 값과 가장 작은 값을 찾기 위함이다.
    
- **연산자 사용**:
    
    각 단계에서는 남은 연산자의 개수에 따라, 덧셈, 뺄셈, 곱셈, 나눗셈 연산을 하나씩 사용하고, 그때마다 연산자 개수를 하나 줄이며 재귀적으로 다음 숫자로 넘어간다.
    
- **결과 출력**:
    
    모든 경우의 수를 탐색한 후, 최댓값과 최솟값을 출력한다.

### 🚩제출한 코드
```
def dfs(level, total, plus, minus, mul, div):
    global max_result
    global min_result
    global n

    #종료 조건
    if level == n:
        max_result = max(total, max_result)
        min_result = min(total, min_result)

    if plus != 0:
        dfs(level + 1, total + nums[level], plus - 1, minus, mul, div)
    if minus != 0:
        dfs(level + 1, total - nums[level], plus, minus - 1, mul, div)
    if mul != 0:
        dfs(level + 1, total * nums[level], plus, minus, mul - 1, div)
    if div != 0:
        dfs(level + 1, int(total / nums[level]), plus, minus, mul, div - 1)


n = int(input())
nums = list(map(int, input().split()))
op = list(map(int, input().split()))

max_result = -int(1e9)
min_result = int(1e9)
dfs(1, nums[0], op[0], op[1], op[2], op[3])

print(max_result)
print(min_result)

```

### 💡TIL
- 1. **DFS와 백트래킹 개념 재확인**:
    
    DFS는 가능한 모든 경로를 탐색하는 방식이다. 이번 문제에서는 연산자의 모든 조합을 탐색하기 때문에 DFS를 이용하여 재귀적으로 가능한 모든 연산 순서를 계산할 수 있었다.
    
- 2. **연산자 처리와 조건부 호출**:
    
    각 연산자의 남은 개수를 조건으로 걸어, 연산자를 사용할 수 있을 때만 재귀적으로 함수를 호출했다. 이를 통해 불필요한 계산을 피할 수 있었다.
    
- 3. **최댓값/최솟값 비교**:
    
    재귀가 끝나는 조건(level == n)에서 최종 계산된 값을 전역 변수 `max_result`와 `min_result`에 각각 비교하며 갱신하는 방식을 사용했다.
    
    
    ---
## [백준 #2644. 촌수계산](https://www.acmicpc.net/problem/2644): 그래프 / 실버2

정리한 링크: https://purple-jury-c2d.notion.site/1111eff69e9e80b989a5ebec49eae05e

### 🚩플로우 (선택)
- **입력받기**:
    - 첫 번째 줄에서 `N`은 노드의 개수(사람 수)를 나타낸다.
    - 두 번째 줄에서는 시작점 `A`와 도착점 `B`를 입력받는다. 이 문제는 `A`에서 `B`까지의 촌수를 계산하는 문제이다.
    - 세 번째 줄에서 `M`은 관계의 개수(엣지 수)를 의미한다. 이후 `M`개의 관계를 입력받아 두 노드 사이에 간선(연결 관계)을 추가하여 그래프를 형성한다.
- **그래프 형성**:
    - `graph`는 인접 리스트로 표현되며, 각 노드 간의 관계가 리스트로 연결된다. `graph[x].append(y)`와 `graph[y].append(x)`로 양방향 연결을 형성한다.
    - `visited` 리스트는 각 노드가 방문되었는지 여부를 기록하는 역할을 한다.
- **DFS 탐색**:
    - `dfs(v, num)` 함수는 DFS 방식으로 노드를 탐색한다.
    - 시작점 `A`에서 탐색을 시작하고, 현재 탐색 중인 노드를 `visited`로 표시한 후, 목표 노드 `B`에 도달하면 촌수(`num`)를 `result` 리스트에 저장한다.
    - 재귀적으로 자식 노드를 탐색하며, 방문하지 않은 노드를 차례로 탐색한다.
- **결과 처리**:
    - DFS 탐색을 완료한 후, `result` 리스트가 비어있다면 `A`에서 `B`로 연결이 없는 것이므로 `1`을 출력한다.
    - 그렇지 않으면, `result[0] - 1`을 출력하여 촌수를 출력한다. (처음 촌수를 1로 시작하므로 출력할 때는 1을 빼준다.)

### 🚩제출한 코드
```

N = int(input())
A, B = map(int, input().split())
M = int(input())
graph = [[] for _ in range(N+1)]
visited = [False] * (N+1)
result = []

for _ in range(M):
  x, y = map(int, input().split())
  graph[x].append(y)
  graph[y].append(x)

# dfs
def dfs(v, num):
  num += 1
  visited[v] = True

  if v == B:
    result.append(num)

  for i in graph[v]:
    if not visited[i]:
      dfs(i, num)

dfs(A, 0)
if len(result) == 0:
  print(-1)
else:
  print(result[0]-1)

```

### 💡TIL
- 그래프 탐색에서 방문 기록을 남기는 `visited` 리스트의 중요성을 다시 확인했다. 이를 통해 불필요한 탐색을 줄이고, 중복되는 계산을 방지할 수 있었다.

- 또한, 경로가 존재하지 않는 경우를 처리하는 조건문 (`if len(result) == 0`)의 필요성을 깨달았다. 다양한 예외 케이스에 대응하는 방식을 고려하는 것이 중요하다는 점을 배웠다.
